### PR TITLE
Add setup function to each engine.

### DIFF
--- a/control.go
+++ b/control.go
@@ -37,12 +37,12 @@ func validateEngine(engine *Engine) (bool, string) {
 //Start - Initialize all engines
 func (control *Control) Start() {
 	for _, engine := range control.Engines {
-		ResetConfigsToDefault()
 		if engine.IsConcurrent {
 			engine.runAsConcurrent()
 		} else {
 			engine.runAsSequential()
 		}
+		ResetConfigsToDefault()
 		log.Println("[CONTROL] Awaiting to start next base. If there is a network error, there will be time to reconnect.")
 		time.Sleep(ControlConfig["ActionDelay"].(time.Duration) * time.Second)
 	}

--- a/control.go
+++ b/control.go
@@ -37,7 +37,7 @@ func validateEngine(engine *Engine) (bool, string) {
 //Start - Initialize all engines
 func (control *Control) Start() {
 	for _, engine := range control.Engines {
-		engine.Setup()
+		engine.doSetup()
 		if engine.IsConcurrent {
 			engine.runAsConcurrent()
 		} else {

--- a/control.go
+++ b/control.go
@@ -37,6 +37,7 @@ func validateEngine(engine *Engine) (bool, string) {
 //Start - Initialize all engines
 func (control *Control) Start() {
 	for _, engine := range control.Engines {
+		engine.Setup()
 		if engine.IsConcurrent {
 			engine.runAsConcurrent()
 		} else {

--- a/engine.go
+++ b/engine.go
@@ -77,6 +77,13 @@ func ElasticClient(client *elastic.Client) func(*Engine) {
 	}
 }
 
+// Setup is executed once before the engine entrypoint.
+func Setup(setup func()) func(*Engine) {
+	return func(engine *Engine) {
+		engine.Setup = setup
+	}
+}
+
 // EntryPoint set a function to start the engine.
 func EntryPoint(entry func(engine *Engine)) func(*Engine) {
 	return func(engine *Engine) {

--- a/engine.go
+++ b/engine.go
@@ -311,3 +311,11 @@ func (engine Engine) logFailure() {
 	str += " Trying to recover from index -> " + strconv.Itoa(engine.Start)
 	log.Println(str)
 }
+
+func (engine Engine) doSetup() {
+	if engine.Setup == nil {
+		DebugPrint("[ENGINE] COURT -> " + engine.Court + " BASE -> " + engine.Base + " has no Setup function.")
+		return
+	}
+	engine.Setup()
+}

--- a/structs.go
+++ b/structs.go
@@ -22,6 +22,7 @@ type Engine struct {
 	IsConcurrent    bool
 	MaxReplicas     int
 	ReplicaRange    int
+	Setup           func()
 	EntryPoint      func(engine *Engine)
 	ResponseChannel chan int
 	Collector       *colly.Collector


### PR DESCRIPTION
Allows devs to define a setup function to be executed once before each engine's start. Inside setup functions devs could change the default configs and/or define some useful behavior to the active engine.
