### PR TITLE
Use private collector for each engine instance

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -256,6 +256,7 @@ func (engine *Engine) runAsConcurrent() {
 
 func (engine Engine) spawnEngine(activeEnginesChannel chan int, maxEnginesChannel chan int, elasticMutex *sync.Mutex) {
 	engine.InitElastic()
+	engine.Collector = GetDefaultcollector()
 	elasticMutex.Lock()
 	connectedToIndex := engine.ConnectedToIndex()
 	elasticMutex.Unlock()


### PR DESCRIPTION
Use private collector for each engine instance
__________________________________________________________________________________________________________


Hotfix to avoid race in Colly wait() method.